### PR TITLE
added node affinity and tolerations for deployment, loki, nginx, and …

### DIFF
--- a/manifests/loki-values.yml
+++ b/manifests/loki-values.yml
@@ -1,0 +1,29 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodeselector
+            operator: In
+            values:
+              - loki-promtail-nginx
+loki:
+  tolerations:
+    - key: "loki-promtail-nginx"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "loki-promtail-nginx"
+      operator: "Equal"
+      value: "true"
+      effect: "NoExecute"
+promtail:
+  tolerations:
+    - key: "loki-promtail-nginx"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "loki-promtail-nginx"
+      operator: "Equal"
+      value: "true"
+      effect: "NoExecute"

--- a/manifests/nginx-values.yml
+++ b/manifests/nginx-values.yml
@@ -1,0 +1,10 @@
+affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: nodeselector
+              operator: In
+              values:
+                - loki-promtail-nginx
+  

--- a/manifests/planetarium-clusterIp.yml
+++ b/manifests/planetarium-clusterIp.yml
@@ -5,7 +5,8 @@ metadata:
   namespace: "default"
   labels:
     app: planetarium
-    job: planetarium-app
+    job: planetarium
+    release: prometheus
 spec:
   ports:
   - name: http

--- a/manifests/prometheus-grafana-values.yml
+++ b/manifests/prometheus-grafana-values.yml
@@ -1,26 +1,35 @@
-prometheusOperator:
-  tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: nodeselector
+              operator: In
+              values:
+                - prometheus
+# prometheusOperator:
+#   tolerations:
+#     - key: "monitoring"
+#       operator: "Equal"
+#       value: "true"
+#       effect: "PreferNoSchedule"
 
-kube-state-metrics:
-  tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+# kube-state-metrics:
+#   tolerations:
+#     - key: "monitoring"
+#       operator: "Equal"
+#       value: "true"
+#       effect: "PreferNoSchedule"
 
 prometheus:
 # DO NOT ADD TOLERATIONS HERE: WILL OVERRIDE PROMETHEUSSPEC TOLERATIONS CAUSING prometheus-prometheus-kube-prometheus-prometheus-0
 # POD IN PENDING STATUS FOREVER!!!
   prometheusSpec: 
-    tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+    # tolerations:
+    # - key: "monitoring"
+    #   operator: "Equal"
+    #   value: "true"
+    #   effect: "PreferNoSchedule"
     serviceAccountName: prometheus
     serviceMonitorNamespaceSelector: {}
     serviceMonitorSelector: 
@@ -45,11 +54,11 @@ prometheus:
         prometheus: socks-shop
       
 grafana:
-  tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+  # tolerations:
+  #   - key: "monitoring"
+  #     operator: "Equal"
+  #     value: "true"
+  #     effect: "PreferNoSchedule"
   # sidecar:
   #   datasources:
   #     tolerations:
@@ -68,24 +77,24 @@ grafana:
     path: /grafana
     ingressClassName: nginx
 
-prometheus-node-exporter:
-  tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
-    - key: "application"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+# prometheus-node-exporter:
+#   tolerations:
+#     - key: "monitoring"
+#       operator: "Equal"
+#       value: "true"
+#       effect: "PreferNoSchedule"
+#     - key: "application"
+#       operator: "Equal"
+#       value: "true"
+#       effect: "PreferNoSchedule"
 
 alertmanager:
-  alertmanagerSpec:
-    tolerations:
-    - key: "monitoring"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
+  # alertmanagerSpec:
+  #   tolerations:
+  #   - key: "monitoring"
+  #     operator: "Equal"
+  #     value: "true"
+  #     effect: "PreferNoSchedule"
 
   config:
     global:

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 			<version>1.18.24</version>
 			<scope>provided</scope>
 		</dependency>
+		
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
Added node affinity and tolerations for deployment, loki, nginx, and prometheus
It seems like I do not really have to taint the nodes... pods were automatically assigned to the designated nodes
By accident I deleted the nginx helm chart. I redownloaded it, but we would need to update our collection URL
Applied servicemonitor and prometheusrules to the cluster... Servicemonitor was the reason of prometheus not getting http server request metrics. Actuator scraping configs were all in the servicemonitor yml file